### PR TITLE
Set explicit version for maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
         <dependencies>
           <dependency>
             <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
Apparently, adding a provider as a plugin dependency requires at least version 2.15 of the maven-surefire-plugin.